### PR TITLE
Auto-add .js extension to names in require() module resolution

### DIFF
--- a/runtime/components/jacMachine/include/features/nodeModules.hpp
+++ b/runtime/components/jacMachine/include/features/nodeModules.hpp
@@ -142,6 +142,9 @@ private:
     std::string resolvePath( const std::string& id ) {
         assert( !id.empty() );
         auto path = fs::concatPath( self()._cfg.basePath, id );
+        if( path.size() >= 3 && path.compare( path.size()-3, 3, ".js" ) != 0 ) {
+            path += ".js";
+        }
         return path;
     }
 


### PR DESCRIPTION
Node.js behaves this way, TS compiles into requires without extension.